### PR TITLE
Send message for the current tab url before making any other message calls to background.

### DIFF
--- a/ext/alertFakeSite/alertFakeSite.js
+++ b/ext/alertFakeSite/alertFakeSite.js
@@ -1,3 +1,4 @@
+console.log('Running alertFakeSite.js');
 function alertFakeSite() {
   $('body').prepend('<div class="fake-site-popup"><p class="fake-site-close">close</p><p class="fake-site-alert">NewsGate has reason to believe this is a fake site.</p></div>');
   $('.fake-site-popup').click(function() {
@@ -6,8 +7,10 @@ function alertFakeSite() {
 }
 
 // Receive the url of the current window from background.html
-chrome.runtime.sendMessage({url: true}, function(response) {
-  if (response.fake) {
+chrome.runtime.sendMessage({action: 'getUrl'}, function(getUrlResponse) {
+  console.log('The current url is: ', getUrlResponse.url);
+  chrome.runtime.sendMessage({action: 'checkUrl', url: response.url}, function(checkUrlResponse) {
+    if ( checkUrlResponse.fake )
     alertFakeSite();
-  }
+  });
 });

--- a/ext/alertFakeSite/checkAddressBarUrl.js
+++ b/ext/alertFakeSite/checkAddressBarUrl.js
@@ -14,10 +14,14 @@ function getCurrentTabUrl(callback) {
 
 chrome.runtime.onMessage.addListener(
   function(request, sender, sendResponse) {
-    var response = {fake: false};
-    getCurrentTabUrl(function(tabUrl) {
-      var url = filterLinks(tabUrl);
-      console.log("URL", url);
+    if (request.action === 'getUrl') {
+      getCurrentTabUrl(function(tabUrl) {
+        sendResponse({url: filterLinks(tabUrl)});
+      });
+    }
+
+    if (request.action === 'checkUrl') {
+      var url = request.url;
       getBlacklist(function(blackList) {
         getUserlist(function(userList) {
           getWhitelist(function(whiteList) {
@@ -29,8 +33,8 @@ chrome.runtime.onMessage.addListener(
           });
         });
       });
-      // allow for an asynchronoous response to alertFakeSite listener
-      return true;
-    });
+    }
+    // allow for an asynchronoous response to alertFakeSite listener
+    return true;
   }
 );


### PR DESCRIPTION
Bug #75 If user loads a page and immediately navigates to a different tab, it will check the site of the different tab and not the expected page.